### PR TITLE
Fixed scraping from MoHFW website

### DIFF
--- a/src/main/java/com/coronaapi/coronarestapi/controller/WebController.java
+++ b/src/main/java/com/coronaapi/coronarestapi/controller/WebController.java
@@ -2,43 +2,38 @@ package com.coronaapi.coronarestapi.controller;
 
 import com.coronaapi.coronarestapi.models.*;
 import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTable;
+import com.gargoylesoftware.htmlunit.html.HtmlTableBody;
+import com.gargoylesoftware.htmlunit.html.HtmlTableRow;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
-import java.util.stream.IntStream;
+import java.util.List;
 
 @RestController
 public class WebController {
 
-	public static final String MOHFW_URL = "https://www.mohfw.gov.in/";
+	public static final String MOHFW_URL = "https://www.mohfw.gov.in/#state-data";
 	public static final String WORLDOMETER_URL = "https://www.worldometers.info/coronavirus/";
 
 	@Scheduled(cron = "* 1 * * * *")
-	@RequestMapping("/india-states-data")
-	public ArrayList<SampleResponse> Sample() throws Exception {
-
-		WebClient client = initializeWebClient();
-		HtmlPage page = client.getPage(MOHFW_URL);
-
-		final HtmlTable table = (HtmlTable) page.getByXPath("//table[@class='statetable table table-striped']").get(0);
-
-		ArrayList<SampleResponse> arrayList = new ArrayList<>();
-
-		for (int i = 1; i < 36; i++) {
-			for (int j = 1; j < 2; j++) {
-				arrayList.add(new SampleResponse(table.getCellAt(i, j).asText(), table.getCellAt(i, j + 4).asText(),
-						table.getCellAt(i, j + 2).asText(), table.getCellAt(i, j + 3).asText()));
-			}
+	@GetMapping("/india-states-data")
+	public ArrayList<IndiaStateModel> getIndiaStatesData() throws Exception {
+		List<HtmlTableRow> rows = getMoHFWData();
+		ArrayList<IndiaStateModel> responseList = new ArrayList<>();
+		for (int i = 0; i < 35; i++) {
+			responseList.add(new IndiaStateModel(rows.get(i).getCell(1).asText(), rows.get(i).getCell(2).asText(),
+					rows.get(i).getCell(4).asText(), rows.get(i).getCell(6).asText()));
 		}
-
-		System.out.println("running....");
-		return arrayList;
+		return responseList;
 	}
 
 	private WebClient initializeWebClient() {
@@ -92,21 +87,14 @@ public class WebController {
 	}
 
 	@Scheduled(cron = "* 1 * * * *")
-	@RequestMapping("/total-in-india")
+	@GetMapping("/total-in-india")
 	public TotalInIndiaModel totalInIndia() throws Exception {
-
-		WebClient client = initializeWebClient();
-		HtmlPage page = client.getPage(MOHFW_URL);
-
-		final HtmlTable table = (HtmlTable) page.getByXPath("//table[@class='table table-striped']").get(0);
+		HtmlTableRow totalsRow = getMoHFWData().get(35);
 
 		TotalInIndiaModel totalInIndia = new TotalInIndiaModel();
-		TotalInIndiaModel finalTotalInIndia = totalInIndia;
-		IntStream.range(37, 38).forEach(index -> {
-			finalTotalInIndia.setTotalConfirmedCases(table.getCellAt(index, 5).asText());
-			finalTotalInIndia.setCured(table.getCellAt(index, 3).asText());
-			finalTotalInIndia.setDeath(table.getCellAt(index, 4).asText());
-		});
+			totalInIndia.setTotalActiveCases(totalsRow.getCell(1).asText());
+			totalInIndia.setCured(totalsRow.getCell(3).asText());
+			totalInIndia.setDeath(totalsRow.getCell(5).asText());
 
 		return totalInIndia;
 	}
@@ -138,29 +126,38 @@ public class WebController {
 	}
 
 	@RequestMapping("/state")
-	public CheckStateModel checkInState(
+	public IndiaStateModel checkInState(
 			@RequestParam(value = "statename", defaultValue = "Maharashtra") String stateName) throws Exception {
 
-		WebClient client = initializeWebClient();
-		HtmlPage page = client.getPage(MOHFW_URL);
-
-		final HtmlTable table = (HtmlTable) page.getByXPath("//table[@class='table table-striped']").get(0);
-
-		CheckStateModel checkStateModel = new CheckStateModel();
-		IntStream.range(1, 36).forEach(index -> {
-			if (StringUtils.containsIgnoreCase(stateName, table.getCellAt(index, 1).asText())) {
+		List<HtmlTableRow> mofhwData = getMoHFWData();
+		IndiaStateModel checkStateModel = new IndiaStateModel();
+		for (int i = 0; i < 35; i++) {
+			if (mofhwData.get(i).getCell(1).asText().equalsIgnoreCase(stateName)) {
 				checkStateModel.setState(stateName);
-				checkStateModel.setTotalConfirmedCases(table.getCellAt(index, 5).asText());
-				checkStateModel.setCured(table.getCellAt(index, 3).asText());
-				checkStateModel.setDeath(table.getCellAt(index, 4).asText());
+				checkStateModel.setTotalActiveCases(mofhwData.get(i).getCell(2).asText());
+				checkStateModel.setCured(mofhwData.get(i).getCell(4).asText());
+				checkStateModel.setDeath(mofhwData.get(i).getCell(6).asText());
+				break;
 			}
-			
-		});
-
-		System.out.println("running....");
+		}
 		return checkStateModel;
 	}
+
+
+	private List<HtmlTableRow> getMoHFWData() throws Exception {
+		WebClient client = initializeWebClient();
+		client.getOptions().setJavaScriptEnabled(true);
+		client.getOptions().setThrowExceptionOnScriptError(false);
+		HtmlPage page = client.getPage(MOHFW_URL);
+		HtmlAnchor needToclick = (HtmlAnchor) page.getFirstByXPath("//*[@class='open-table']");
+		needToclick.click();
+		client.waitForBackgroundJavaScript(2000);
+		page = (HtmlPage) client.getCurrentWindow().getEnclosedPage();
+		HtmlTableBody body = (HtmlTableBody) page.getByXPath("//*[@class='statetable table table-striped']/tbody").get(0);
+		return body.getRows();
+	}
 }
+
 
 //@RequestMapping("/country")
 //public ArrayList<CheckedCountryModel> checkCountry(@RequestParam(value = "countryname",

--- a/src/main/java/com/coronaapi/coronarestapi/models/IndiaStateModel.java
+++ b/src/main/java/com/coronaapi/coronarestapi/models/IndiaStateModel.java
@@ -1,0 +1,53 @@
+package com.coronaapi.coronarestapi.models;
+
+public class IndiaStateModel {
+    private String state;
+    private String totalActiveCases;
+    private String cured;
+    private String death;
+
+    public IndiaStateModel(String state, String totalActiveCases, String cured, String death) {
+        super();
+        this.state = state;
+        this.totalActiveCases = totalActiveCases;
+        this.cured = cured;
+        this.death = death;
+    }
+
+    public IndiaStateModel() {
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getTotalActiveCases() {
+        return totalActiveCases;
+    }
+
+    public void setTotalActiveCases(String totalActiveCases) {
+        this.totalActiveCases = totalActiveCases;
+    }
+
+    public String getCured() {
+        return cured;
+    }
+
+    public void setCured(String cured) {
+        this.cured = cured;
+    }
+
+    public String getDeath() {
+        return death;
+    }
+
+    public void setDeath(String death) {
+        this.death = death;
+    }
+
+
+}

--- a/src/main/java/com/coronaapi/coronarestapi/models/TotalInIndiaModel.java
+++ b/src/main/java/com/coronaapi/coronarestapi/models/TotalInIndiaModel.java
@@ -2,7 +2,7 @@ package com.coronaapi.coronarestapi.models;
 
 public class TotalInIndiaModel {
 
-	String totalConfirmedCases;
+	String totalActiveCases;
 	String cured;
 	String death;
 	
@@ -10,9 +10,9 @@ public class TotalInIndiaModel {
 	
 	
 	
-	public TotalInIndiaModel(String totalConfirmedCases, String cured, String death) {
+	public TotalInIndiaModel(String totalActiveCases, String cured, String death) {
 		super();
-		this.totalConfirmedCases = totalConfirmedCases;
+		this.totalActiveCases = totalActiveCases;
 		this.cured = cured;
 		this.death = death;
 	}
@@ -21,11 +21,11 @@ public class TotalInIndiaModel {
 
     }
 
-    public String getTotalConfirmedCases() {
-		return totalConfirmedCases;
+    public String getTotalActiveCases() {
+		return totalActiveCases;
 	}
-	public void setTotalConfirmedCases(String totalConfirmedCases) {
-		this.totalConfirmedCases = totalConfirmedCases;
+	public void setTotalActiveCases(String totalActiveCases) {
+		this.totalActiveCases = totalActiveCases;
 	}
 	public String getCured() {
 		return cured;


### PR DESCRIPTION
Hi - I came across this issue as you have tagged it under Hacktoberfest and have attempted to fix it to best of my ability - 

Solution for #7 #8  #9  - 
On looking at the XML that was being returned I found that the table body was not being captured, this was due to the behaviour of webpage where we need to click on the "Click to expand" link in order to view the table. I enabled javascript in the webclient and added that functionality to click and then fetch page from the controller.  

Also created/updated the response model as the MoHFW website displays active cases for state and not total confirmed cases for state. 

While this immediately fixes the issues you mentioned above, it introduces performance issues that might need to be optimised - 

1) The webclient waits 2s for the javascript to load in the background adding latency
2) If javascript load fails - it gives IndexOutOfBoundsError

One possible solution is to introduce a cache with a 24 hour TTL as the website refreshes data everyday. 

![image](https://user-images.githubusercontent.com/19893222/94369770-5e199380-0109-11eb-8220-9509bf9fbb5c.png)
![image](https://user-images.githubusercontent.com/19893222/94369803-843f3380-0109-11eb-8244-f312fb629e12.png)
![image](https://user-images.githubusercontent.com/19893222/94369814-93be7c80-0109-11eb-8438-d44aafe61c84.png)

